### PR TITLE
Auto-update .watchman config file 

### DIFF
--- a/blueprints/ember-fountainhead/index.js
+++ b/blueprints/ember-fountainhead/index.js
@@ -1,5 +1,7 @@
 'use strict';
 const EOL = require('os').EOL;
+const readWatchmanConfig = require('./read-watchman-config');
+const updateWatchmanConfig = require('./update-watchman-config');
 
 /**
  * When an addon has an `index.js` file under `/blueprints/ADDON_NAME`, Ember
@@ -33,6 +35,17 @@ module.exports = {
    * @return {undefined}
    */
   afterInstall() {
+    let watchmanConfig;
+
+    if (this.project.isEmberCLIAddon()) {
+      // Reads the project's .watchmanconfig file
+      watchmanConfig = readWatchmanConfig();
+      // Adds the public folder in a test dummy app to the ignore_dirs prop
+      // in the .watchmanconfig file to prevent infinite rerenders when docs
+      // are built on live reload.
+      updateWatchmanConfig(watchmanConfig);
+    }
+
     console.log(`Thanks for installing Ember Fountainhead${EOL}You can run 'ember-docs' to generate you documentation`);
   }
 };

--- a/index.js
+++ b/index.js
@@ -107,7 +107,9 @@ module.exports = {
    * @return {undefined}
    */
   preBuild() {
-    if (config.liveEdit !== false) { generateDocs(); }
+    const env = process.env.EMBER_ENV || 'development';
+
+    if (env === 'development' && config.liveEdit !== false) { generateDocs(); }
   }
 
   // Fallback exclude feature if we need to nix using

--- a/lib/.watchmanconfig.spec
+++ b/lib/.watchmanconfig.spec
@@ -1,0 +1,1 @@
+{"ignore_dirs":["tmp","dist"]}

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ module.exports = function() {
    * @type {Object}
    */
 
-  let fountainheadConfig, packageJSON, watchmanConfig;
+  let fountainheadConfig, packageJSON;
 
   // You never know.
   try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,8 @@ const Y = require('yuidocjs');
 const decorateConfig = require('./decorate-config');
 const createDirs = require('./create-dirs');
 const generateFountainheadData = require('./generate-fountainhead-data');
-
+const readWatchmanConfig = require('./read-watchman-config');
+const updateWatchmanConfig = require('./update-watchman-config');
 
 /**
  * Fountainhead documentation data generation lib entry. Configuration is set
@@ -25,6 +26,8 @@ const generateFountainheadData = require('./generate-fountainhead-data');
  * @uses decorateConfig
  * @uses createDirs
  * @uses generateFountainheadData
+ * @uses readWatchmanConfig
+ * @uses updateWatchmanConfig
  */
 module.exports = function() {
 
@@ -43,7 +46,7 @@ module.exports = function() {
    * @type {Object}
    */
 
-  let fountainheadConfig, packageJSON;
+  let fountainheadConfig, packageJSON, watchmanConfig;
 
   // You never know.
   try {
@@ -60,6 +63,12 @@ module.exports = function() {
   // Validate config output
   fountainheadConfig = decorateConfig(fountainheadConfig, packageJSON);
 
+  // Reads a ember-cli project's .watchmanconfig file
+  watchmanConfig = readWatchmanConfig(packageJSON);
+
+  // Adds the public folder in a test dummy app to the ignore_dirs prop
+  // in an addon's .watchmanconfig file
+  updateWatchmanConfig(packageJSON, watchmanConfig);
 
   // ========================================================
   // Exec Docs Generation

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,8 +5,6 @@ const Y = require('yuidocjs');
 const decorateConfig = require('./decorate-config');
 const createDirs = require('./create-dirs');
 const generateFountainheadData = require('./generate-fountainhead-data');
-const readWatchmanConfig = require('./read-watchman-config');
-const updateWatchmanConfig = require('./update-watchman-config');
 
 /**
  * Fountainhead documentation data generation lib entry. Configuration is set
@@ -26,8 +24,6 @@ const updateWatchmanConfig = require('./update-watchman-config');
  * @uses decorateConfig
  * @uses createDirs
  * @uses generateFountainheadData
- * @uses readWatchmanConfig
- * @uses updateWatchmanConfig
  */
 module.exports = function() {
 
@@ -62,13 +58,6 @@ module.exports = function() {
 
   // Validate config output
   fountainheadConfig = decorateConfig(fountainheadConfig, packageJSON);
-
-  // Reads a ember-cli project's .watchmanconfig file
-  watchmanConfig = readWatchmanConfig(packageJSON);
-
-  // Adds the public folder in a test dummy app to the ignore_dirs prop
-  // in an addon's .watchmanconfig file
-  updateWatchmanConfig(packageJSON, watchmanConfig);
 
   // ========================================================
   // Exec Docs Generation

--- a/lib/read-watchman-config.js
+++ b/lib/read-watchman-config.js
@@ -7,21 +7,13 @@ const fs = require('fs');
  * Parses an ember-cli project's .watchmanconfig file and converts to JSON
  * @class readWatchmanConfig
  * @constructor
+ * @param {string} watchmanConfigFilepath The filepath for a .watchmanconfig file
+ * @return {Object} The .watchmanconfig file converted to JSON
  */
-module.exports = function readWatchmanConfig(
-  packageJSON,
-  watchmanConfigFilepath
-) {
+module.exports = function readWatchmanConfig(watchmanConfigFilepath) {
   let watchmanConfig, watchmanConfigText;
 
   watchmanConfigFilepath = watchmanConfigFilepath || '.watchmanconfig';
-
-  // Don't update the watchman config file if we're not in an ember addon
-  // project because they don't have test dummy app.
-  if (packageJSON.keywords &&
-    packageJSON.keywords.indexOf('ember-addon') === -1) {
-    return;
-  }
 
   // Read watchman config file and parse as json
   try {

--- a/lib/read-watchman-config.js
+++ b/lib/read-watchman-config.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * Parses an ember-cli project's .watchmanconfig file and converts to JSON
+ * @class readWatchmanConfig
+ * @constructor
+ */
+module.exports = function readWatchmanConfig(
+  packageJSON,
+  watchmanConfigFilepath = '.watchmanconfig'
+) {
+  let watchmanConfig, watchmanConfigText;
+
+  // Don't update the watchman config file if we're not in an ember addon
+  // project because they don't have test dummy app.
+  if (packageJSON.keywords &&
+    packageJSON.keywords.indexOf('ember-addon') === -1) {
+    return;
+  }
+
+  // Read watchman config file and parse as json
+  try {
+    watchmanConfigText = fs.readFileSync(path.resolve(watchmanConfigFilepath), { encoding: 'utf8' });
+    watchmanConfig = JSON.parse(watchmanConfigText);
+  } catch(ex) {
+    watchmanConfig = {};
+    console.warn('Failed to read file: .watchmanconfig');
+  }
+
+  return watchmanConfig;
+};

--- a/lib/read-watchman-config.js
+++ b/lib/read-watchman-config.js
@@ -10,9 +10,11 @@ const fs = require('fs');
  */
 module.exports = function readWatchmanConfig(
   packageJSON,
-  watchmanConfigFilepath = '.watchmanconfig'
+  watchmanConfigFilepath
 ) {
   let watchmanConfig, watchmanConfigText;
+
+  watchmanConfigFilepath = watchmanConfigFilepath || '.watchmanconfig';
 
   // Don't update the watchman config file if we're not in an ember addon
   // project because they don't have test dummy app.

--- a/lib/read-watchman-config.spec.js
+++ b/lib/read-watchman-config.spec.js
@@ -3,14 +3,8 @@ const readWatchmanConfig = require('./read-watchman-config');
 
 describe('read-watchman-config', function() {
   it('reads .watchmanconfig file as JSON', () => {
-    let packageJSON, watchmanConfig;
 
-    // Test Addon Scenario
-    packageJSON = {
-      keywords: ['ember-addon']
-    };
-
-    watchmanConfig = readWatchmanConfig(packageJSON, './lib/.watchmanconfig.spec');
+    let watchmanConfig = readWatchmanConfig('./lib/.watchmanconfig.spec');
 
     assert.deepEqual(watchmanConfig, { ignore_dirs: ['tmp','dist'] });
   });

--- a/lib/read-watchman-config.spec.js
+++ b/lib/read-watchman-config.spec.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+const readWatchmanConfig = require('./read-watchman-config');
+
+describe('read-watchman-config', function() {
+  it('reads .watchmanconfig file as JSON', () => {
+    let packageJSON, watchmanConfig;
+
+    // Test Addon Scenario
+    packageJSON = {
+      keywords: ['ember-addon']
+    };
+
+    watchmanConfig = readWatchmanConfig(packageJSON, './lib/.watchmanconfig.spec');
+
+    assert.deepEqual(watchmanConfig, { ignore_dirs: ['tmp','dist'] });
+  });
+});

--- a/lib/update-watchman-config.js
+++ b/lib/update-watchman-config.js
@@ -12,20 +12,15 @@ let outputJson;
  * into an addon's dummy/public folder.
  * @class updateWatchmanConfig
  * @constructor
+ * @param {Object} watchmanConfig The .watchmanconfig file object
+ * @param {String} watchmanConfigFilepath The filepath for a .watchmanconfig file
+ * @return {undefined}
  */
 module.exports = function updateWatchmanConfig(
-  packageJSON,
   watchmanConfig,
   watchmanConfigFilepath
 ) {
   watchmanConfigFilepath = watchmanConfigFilepath || '.watchmanconfig';
-
-  // Don't update the watchman config file if we're not in an ember addon
-  // project because they don't have test dummy app.
-  if (packageJSON.keywords &&
-    packageJSON.keywords.indexOf('ember-addon') === -1) {
-    return;
-  }
 
   // Add the dummy app public path to the ignore_dirs property in the config
   if (watchmanConfig.ignore_dirs &&

--- a/lib/update-watchman-config.js
+++ b/lib/update-watchman-config.js
@@ -1,0 +1,44 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const dummyPublicPath = 'tests/dummy/public';
+
+let outputJson;
+
+/**
+ * Adds a new filepath to a ember addon projects .watchmanconfig file to
+ * prevent live reload from going into an infinite loop when docs are built
+ * into an addon's dummy/public folder.
+ * @class updateWatchmanConfig
+ * @constructor
+ */
+module.exports = function updateWatchmanConfig(
+  packageJSON,
+  watchmanConfig,
+  watchmanConfigFilepath = '.watchmanconfig'
+) {
+
+  // Don't update the watchman config file if we're not in an ember addon
+  // project because they don't have test dummy app.
+  if (packageJSON.keywords &&
+    packageJSON.keywords.indexOf('ember-addon') === -1) {
+    return;
+  }
+
+  // Add the dummy app public path to the ignore_dirs property in the config
+  if (watchmanConfig.ignore_dirs &&
+      watchmanConfig.ignore_dirs.indexOf(dummyPublicPath) === -1) {
+    watchmanConfig.ignore_dirs.push(dummyPublicPath);
+  } else {
+    return;
+  }
+
+  // Save the updated config
+  try {
+    outputJson = JSON.stringify(watchmanConfig);
+    fs.writeFileSync(path.resolve(watchmanConfigFilepath), outputJson, { encoding: 'utf8' });
+  } catch(ex) {
+    console.log('Failed to write file: .watchmanconfig');
+  }
+};

--- a/lib/update-watchman-config.js
+++ b/lib/update-watchman-config.js
@@ -16,8 +16,9 @@ let outputJson;
 module.exports = function updateWatchmanConfig(
   packageJSON,
   watchmanConfig,
-  watchmanConfigFilepath = '.watchmanconfig'
+  watchmanConfigFilepath
 ) {
+  watchmanConfigFilepath = watchmanConfigFilepath || '.watchmanconfig';
 
   // Don't update the watchman config file if we're not in an ember addon
   // project because they don't have test dummy app.

--- a/lib/update-watchman-config.spec.js
+++ b/lib/update-watchman-config.spec.js
@@ -15,18 +15,13 @@ describe('update-watchman-config', function() {
   });
 
   it('updates .watchmanconfig file ignore_dirs property with new filepath', () => {
-    let packageJSON, watchmanConfig, watchmanConfigText;
-
-    // Test Addon Scenario
-    packageJSON = {
-      keywords: ['ember-addon']
-    };
+    let watchmanConfig, watchmanConfigText;
 
     watchmanConfig = {
       ignore_dirs: ['tmp', 'dist']
     };
 
-    updateWatchmanConfig(packageJSON, watchmanConfig, './lib/.watchmanconfig-after.spec');
+    updateWatchmanConfig(watchmanConfig, './lib/.watchmanconfig-after.spec');
 
     try {
       watchmanConfigText = fs.readFileSync(path.resolve('./lib/.watchmanconfig-after.spec'), { encoding: 'utf8' });

--- a/lib/update-watchman-config.spec.js
+++ b/lib/update-watchman-config.spec.js
@@ -1,0 +1,41 @@
+const path = require('path');
+const fs = require('fs');
+const assert = require('assert');
+const updateWatchmanConfig = require('./update-watchman-config');
+
+describe('update-watchman-config', function() {
+
+  after(function() {
+    // Remove test output file after testing
+    try {
+      fs.unlinkSync(path.resolve('./lib/.watchmanconfig-after.spec'));
+    } catch(ex) {
+      console.warn('Failed to delete file: .watchmanconfig');
+    }
+  });
+
+  it('updates .watchmanconfig file ignore_dirs property with new filepath', () => {
+    let packageJSON, watchmanConfig, watchmanConfigText;
+
+    // Test Addon Scenario
+    packageJSON = {
+      keywords: ['ember-addon']
+    };
+
+    watchmanConfig = {
+      ignore_dirs: ['tmp', 'dist']
+    };
+
+    updateWatchmanConfig(packageJSON, watchmanConfig, './lib/.watchmanconfig-after.spec');
+
+    try {
+      watchmanConfigText = fs.readFileSync(path.resolve('./lib/.watchmanconfig-after.spec'), { encoding: 'utf8' });
+      watchmanConfig = JSON.parse(watchmanConfigText);
+    } catch(ex) {
+      watchmanConfig = {};
+      console.warn('Failed to read file: .watchmanconfig');
+    }
+
+    assert.deepEqual(watchmanConfig, { ignore_dirs: ['tmp','dist', 'tests/dummy/public'] });
+  });
+});


### PR DESCRIPTION
Update an ember addon project's .watchmanconfig file to ignore dummy app doc changes on live reload. I split out the read and update logic so we can test each one without having to run the entire `generateDocs` function.

Also fixes #9.