### PR TITLE
:sparkles: Check Ember version to construct correct template path

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-version-checker": "^1.2.0",
     "markdown-it": "^8.0.0",
     "prismjs": "^1.5.1",
     "yuidocjs": "^0.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1751,7 +1751,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7:
+ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.2.0.tgz#caa286b77d1b485df5d2f62c67a6f19aa8b582c4"
   dependencies:


### PR DESCRIPTION
Handle importing the template compiler from npm modules instead of bower for Ember v2.11+

Note that it looks like npm imports are working with 2.11+ which has been kind of promised, but if this doesn't work for everyone we'll switch to using the standard treeForVendor Funnel => app.import on /vendor pattern.