### PR TITLE
Using `\n` to delimit glimmer block causes unexpected output

### DIFF
--- a/lib/parse-markdown.js
+++ b/lib/parse-markdown.js
@@ -61,7 +61,7 @@ const md = require('markdown-it')({
 const renderCodeBlocks = function(description) {
   // Look for triple backtick code blocks flagged as `glimmer`;
   // define end of block as triple backticks followed by a newline
-  let matches = description.match(/(```glimmer)(.|\n)*?```\n/gi);
+  let matches = description.match(/(```glimmer)(.|\n)*?```/gi);
 
   if (matches && matches.length) {
     matches.map(codeBlock => {


### PR DESCRIPTION
Given a `glimmer` tag at the end of comment block, a partial is not generated.

For example

 \* \```glimmer
 \* {{#fountainhead-button}}Check me out{{/fountainhead-button}}
 \* \```
 \*
 \* @class FountainheadButton

Will result in the handlebars being output, but _not_ the button component.

