### PR TITLE
[WIP] Feature/data for code blocks

### DIFF
--- a/addon/routes/api/modules.js
+++ b/addon/routes/api/modules.js
@@ -19,7 +19,6 @@ export default Route.extend({
    * @return {Promise} jQuery ajax promise
    */
   model(params) {
-    console.log('model');
     return $.ajax(`${this.get('fountainhead.apiNamespace')}/modules/${params.module_id}.json`);
   },
 

--- a/guides/tools.md
+++ b/guides/tools.md
@@ -57,6 +57,22 @@ Will actually be parsed as:
 <span class="token punctuation">{</span><span class="token punctuation">{</span>some<span class="token operator">-</span>component example<span class="token operator">=</span><span class="token boolean">true</span><span class="token punctuation">}</span><span class="token punctuation">}</span>
 </code></pre>
 
+You can also add data when rendering you components, this is super useful for showing
+variations of a theme or components in different states.
+
+At the top of your `glimmer` add data using a JSON string
+e.g. `data={"things": ["Red", "Green", "Blue"]}`.  This will make every top level key available
+to your example and will be stripped from the displayed code.
+
+You can then use the properties in the template.
+
+```glimmer
+data={"colors": ["Red", "Green", "Blue"]}
+{{#each colors as |color|}}
+  <button>{{color}}</button>
+{{/each}}
+```
+
 ## Markdown in DocBlock Descriptions and Guides
 Fountainhead has full support for markdown in documentation blocks and guides.
 If you're not familiar with markdown, you can start with a tutorial at

--- a/lib/parse-markdown.js
+++ b/lib/parse-markdown.js
@@ -8,6 +8,8 @@ require('prismjs/components/prism-diff');
 require('prismjs/components/prism-json');
 require('prismjs/components/prism-scss');
 
+var stripDataTags = require('./strip-data-tag');
+
 /**
  * Handle parsing markdown using [Prism](http://prismjs.com/)
  * @class parseMarkdown
@@ -24,11 +26,11 @@ const md = require('markdown-it')({
     // We support flagging code blocks with `glimmer` or `htmlbars`, but Prism
     // only recognizes 'handlebars'
     if (lang === 'glimmer' || lang === 'htmlbars' ) { lang = 'handlebars'; }
-
+    let stripped = stripDataTags(str);
     if (lang && Prism.languages[lang]) {
       try {
         return `<pre class=\"language-${lang}\"><code class=\"language-${lang}\">` +
-          Prism.highlight(str, Prism.languages.javascript) +
+          Prism.highlight(stripped, Prism.languages.javascript) +
           '</code></pre>';
       } catch(ex) {
         console.warn('Failed parsing language: ', ex);

--- a/lib/strip-data-tag.js
+++ b/lib/strip-data-tag.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function stripDataTags(docString) {
+  var dataStripper = /(data=({.*}))\n/;
+  return docString.replace(dataStripper, '');
+};


### PR DESCRIPTION
Not sure if you folks would be interested in this, but here's an idea.

Building Ember components from the `glimmer` blocks is super nice, but wouldn't it be even nicer if you could provide some data to them as well?

```glimmer
data={"colors": ["Red", "Green", "Blue"]}
{{#each colors as |color|}}
  <button>{{color}}</button>
{{/each}}
```
Using a `data=` identifier followed by some JSON, this adds the property `colors` to the component, making it available to the generated template.  Now you can render out every different color variant of a button or put components into different states without having to manually type out examples of every variant.

Feedback appreciated 🎉 